### PR TITLE
Add access to the display state of the accessibility handler

### DIFF
--- a/example/app/source/MainComponent.h
+++ b/example/app/source/MainComponent.h
@@ -45,6 +45,7 @@ public:
         _incrementButton.setTitle ("Increment button title");
         _incrementButton.setDescription ("Increment button description");
         _incrementButton.setHelpText ("Increment button help text");
+        _incrementButton.setTooltip ("Increment button tool tip");
 
         _decrementButton.setAccessible (false);
     }
@@ -91,6 +92,7 @@ private:
         if (newValue != _value)
         {
             _value = newValue;
+            _slider.setValue (_value, juce::NotificationType::dontSendNotification);
             updateLabel ();
         }
     }

--- a/example/tests/accessibility.spec.ts
+++ b/example/tests/accessibility.spec.ts
@@ -19,9 +19,10 @@ describe('Accessibility tests', () => {
     expect((await appConnection.getAccessibilityState('increment-button'))).toEqual({
         "title": 'Increment button title',
         "description": 'Increment button description',
-        "help": 'Increment button help text',
+        "help": 'Increment button tool tip',
         "accessible": true,
         "handler": true,
+        "display": ''
     });
   });
 
@@ -41,5 +42,16 @@ describe('Accessibility tests', () => {
     const state = await appConnection.getAccessibilityState('slider');
     expect(state.accessible).toBeTruthy();
     expect(state.handler).toBeTruthy();
+    expect(parseFloat (state.display)).toEqual(0);
+  });
+
+  it('Slider display changes with the value change', async () => {
+    expect(parseFloat ((await appConnection.getAccessibilityState('slider')).display)).toEqual(0);
+
+    await appConnection.clickComponent('increment-button');
+    expect(parseFloat ((await appConnection.getAccessibilityState('slider')).display)).toEqual(1);
+
+    await appConnection.clickComponent('decrement-button');
+    expect(parseFloat ((await appConnection.getAccessibilityState('slider')).display)).toEqual(0);
   });
 });

--- a/source/cpp/source/DefaultCommandHandler.cpp
+++ b/source/cpp/source/DefaultCommandHandler.cpp
@@ -477,6 +477,41 @@ Response setComboBoxSelectedItemIndex (const Command & command)
     return Response::fail (error);
 }
 
+juce::String getAccessibilityHandlerDisplay (juce::Component & component)
+{
+    if (! component.isAccessible () || component.getAccessibilityHandler () == nullptr)
+        return "";
+
+    if (auto * value = component.getAccessibilityHandler ()->getValueInterface ())
+        return value->getCurrentValueAsString ();
+
+    if (auto * text = component.getAccessibilityHandler ()->getTextInterface ())
+        return text->getAllText ();
+
+    return "";
+}
+
+juce::String getAccessibilityTitle (juce::Component & component)
+{
+    return (component.isAccessible () && component.getAccessibilityHandler () != nullptr)
+               ? component.getAccessibilityHandler ()->getTitle ()
+               : component.getTitle ();
+}
+
+juce::String getAccessibilityDescription (juce::Component & component)
+{
+    return (component.isAccessible () && component.getAccessibilityHandler () != nullptr)
+               ? component.getAccessibilityHandler ()->getDescription ()
+               : component.getDescription ();
+}
+
+juce::String getAccessibilityHelpText (juce::Component & component)
+{
+    return (component.isAccessible () && component.getAccessibilityHandler () != nullptr)
+               ? component.getAccessibilityHandler ()->getHelp ()
+               : component.getHelpText ();
+}
+
 Response getAccessibilityState (const Command & command)
 {
     const auto componentId = command.getArgument (toString (CommandArgument::componentId));
@@ -485,11 +520,12 @@ Response getAccessibilityState (const Command & command)
 
     if (auto * component = ComponentSearch::findWithId (componentId))
         return Response::ok ()
-            .withParameter (toString (CommandArgument::title), component->getTitle ())
-            .withParameter ("description", component->getDescription ())
-            .withParameter ("help", component->getHelpText ())
+            .withParameter (toString (CommandArgument::title), getAccessibilityTitle (*component))
+            .withParameter ("description", getAccessibilityDescription (*component))
+            .withParameter ("help", getAccessibilityHelpText (*component))
             .withParameter ("accessible", component->isAccessible ())
-            .withParameter ("handler", component->getAccessibilityHandler () != nullptr);
+            .withParameter ("handler", component->getAccessibilityHandler () != nullptr)
+            .withParameter ("display", getAccessibilityHandlerDisplay (*component));
 
     return Response::fail (componentId + " not found");
 }

--- a/source/ts/responses.ts
+++ b/source/ts/responses.ts
@@ -34,6 +34,7 @@ export interface AccessibilityResponse {
   help: string;
   accessible: boolean;
   handler: boolean;
+  display: string;
 }
 
 export enum ResponseType {


### PR DESCRIPTION
**Describe what your code does**

Adds the ability to get the accessibility handler string output for value and text features

**Is this pull request to fix a bug?**

Slightly - previous implementation called the same as the default handler. This wouldn't work for customised items

