### PR TITLE
Add `waitForResult` utility 

### DIFF
--- a/source/ts/index.ts
+++ b/source/ts/index.ts
@@ -1,4 +1,4 @@
 export {AppConnection, EnvironmentVariables} from './app-connection';
 export {Command} from './commands';
 export {Response, Event} from './responses';
-export {pollUntil} from './poll';
+export {pollUntil, waitForResult} from './poll';

--- a/source/ts/poll.ts
+++ b/source/ts/poll.ts
@@ -1,12 +1,10 @@
+const DEFAULT_TIMEOUT = 10000;
+
 export async function pollUntil<T>(
   matchingFunction: (data: T) => boolean,
   queryFunction: () => Promise<T>,
-  timeout?: number
+  timeout = DEFAULT_TIMEOUT
 ): Promise<boolean> {
-  if (!timeout) {
-    timeout = 10000;
-  }
-
   return new Promise((resolve) => {
     const timeoutTimer = setTimeout(() => {
       resolve(false);
@@ -26,4 +24,20 @@ export async function pollUntil<T>(
 
     query();
   });
+}
+
+export async function waitForResult<T>(
+  queryFunction: () => Promise<T>,
+  expectedResult: T,
+  timeoutMs = DEFAULT_TIMEOUT
+): Promise<void> {
+  const result = await pollUntil(
+    (currentResult) => currentResult === expectedResult,
+    queryFunction,
+    timeoutMs
+  );
+
+  if (!result) {
+    throw new Error(`Result didn't become ${expectedResult}`);
+  }
 }

--- a/tests/wait-for-result.spec.ts
+++ b/tests/wait-for-result.spec.ts
@@ -1,0 +1,24 @@
+import {waitForResult} from '../source/ts/poll';
+
+describe('waiting for a function to return a particular value', () => {
+  const functionThatReturns42 = () => Promise.resolve(42);
+  const timeoutMs = 10;
+
+  it('becomes the expected value within the timeout time', async () => {
+    const expectedValue = 42;
+
+    await waitForResult(
+      () => functionThatReturns42(),
+      expectedValue,
+      timeoutMs
+    );
+  });
+
+  it('throws when the function does not return the expected value within the timeout time', async () => {
+    const expectedValue = 13;
+
+    expect(
+      waitForResult(() => functionThatReturns42(), expectedValue, timeoutMs)
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
**Describe what your code does**

Adds a utility function, `waitForResult`, which lets you wait on an exact result from an async function (polling internally).

**Is this pull request to fix a bug?**

Fixes a bug with `pollUntil`, causing a hang when the query function returns immediately in the same frame. This is unlikely to occur in practice however it came to light when writing tests for the new function.

**Is this pull request to extend the functionality of the codebase?**

Yes. It prevents you from having to rewrite the same matching function over again (`(currentResult) => currentResult === expectedResult`) in e2e test code.

For example, instead of this:

```
test('the colour is changed to red', async () => {
  const found = await pollUntil(
    (colourName) => colourName === "red",
    async () => await app.getColourName()
  );

  expect(found).toBe(true);
});
```

You can now do this:

```
test('the colour is changed to red', async () => {
  await waitForResult(() => app.getColourName(), "red");
});
```

**Is the code tested?**

Yes