### PR TITLE
Fix `waitForComponentEnablementToBe`

### DIFF
--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -392,7 +392,7 @@ export class AppConnection extends EventEmitter {
   ): Promise<boolean> {
     try {
       await waitForResult(
-        () => this.getComponentVisibility(componentName),
+        () => this.getComponentEnablement(componentName),
         enablement,
         timeoutInMilliseconds
       );


### PR DESCRIPTION
**Describe what your code does**

Fixes an issue introduced in https://github.com/FocusriteGroup/juce-end-to-end/pull/138, where `waitForComponentEnablementToBe` was refactored to make use of the new `waitForResult` utility, so it has now stopped working.

It was refactored to wait for the wrong result (visibility rather than enablement) 🙈 

---

By submitting a pull request to this repository you are agreeing to assign the copyright on your submitted code to Focusrite Audio Engineering Ltd. Please check the box below to show you accept these terms. 

- [x] __I agree to assign copyright of any code accepted via this pull request process to Focusrite Audio engineering Ltd.__
