### PR TITLE
Fix build

### DIFF
--- a/example/app/CMakeLists.txt
+++ b/example/app/CMakeLists.txt
@@ -1,3 +1,22 @@
+add_library(juce_modules STATIC)
+add_library(focusrite-e2e::juce_modules ALIAS juce_modules)
+
+target_link_libraries(juce_modules PRIVATE juce::juce_gui_extra)
+
+# We're linking the modules privately, but we need to export
+# their compile flags
+target_compile_definitions(juce_modules
+    PUBLIC
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+    INTERFACE
+        $<TARGET_PROPERTY:juce_modules,COMPILE_DEFINITIONS>)
+
+# We also need to export the include directories for the modules
+target_include_directories(juce_modules
+    INTERFACE
+        $<TARGET_PROPERTY:juce_modules,INCLUDE_DIRECTORIES>)
+
 juce_add_gui_app (e2e-example-app VERSION 0.0.0)
 
 target_sources (
@@ -12,14 +31,12 @@ target_compile_definitions (
   e2e-example-app
   PRIVATE
     DONT_SET_USING_JUCE_NAMESPACE=1
-    JUCE_WEB_BROWSER=0
-    JUCE_USE_CURL=0
     JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:e2e-example-app,JUCE_PRODUCT_NAME>"
     JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:e2e-example-app,JUCE_VERSION>"
 )
 
 target_link_libraries (
-  e2e-example-app PRIVATE juce::juce_gui_extra
+e2e-example-app INTERFACE juce_modules
   PUBLIC juce::juce_recommended_config_flags juce::juce_recommended_lto_flags
          juce::juce_recommended_warning_flags)
 

--- a/example/app/CMakeLists.txt
+++ b/example/app/CMakeLists.txt
@@ -1,21 +1,16 @@
-add_library(juce_modules STATIC)
-add_library(focusrite-e2e::juce_modules ALIAS juce_modules)
+add_library (juce_modules STATIC)
+add_library (focusrite-e2e::juce_modules ALIAS juce_modules)
 
-target_link_libraries(juce_modules PRIVATE juce::juce_gui_extra)
+target_link_libraries (juce_modules PRIVATE juce::juce_gui_extra)
 
-# We're linking the modules privately, but we need to export
-# their compile flags
-target_compile_definitions(juce_modules
-    PUBLIC
-        JUCE_WEB_BROWSER=0
-        JUCE_USE_CURL=0
-    INTERFACE
-        $<TARGET_PROPERTY:juce_modules,COMPILE_DEFINITIONS>)
+# We're linking the modules privately, but we need to export their compile flags
+target_compile_definitions (
+  juce_modules PUBLIC JUCE_WEB_BROWSER=0 JUCE_USE_CURL=0
+  INTERFACE $<TARGET_PROPERTY:juce_modules,COMPILE_DEFINITIONS>)
 
 # We also need to export the include directories for the modules
-target_include_directories(juce_modules
-    INTERFACE
-        $<TARGET_PROPERTY:juce_modules,INCLUDE_DIRECTORIES>)
+target_include_directories (
+  juce_modules INTERFACE $<TARGET_PROPERTY:juce_modules,INCLUDE_DIRECTORIES>)
 
 juce_add_gui_app (e2e-example-app VERSION 0.0.0)
 
@@ -36,7 +31,7 @@ target_compile_definitions (
 )
 
 target_link_libraries (
-e2e-example-app INTERFACE juce_modules
+  e2e-example-app INTERFACE juce_modules
   PUBLIC juce::juce_recommended_config_flags juce::juce_recommended_lto_flags
          juce::juce_recommended_warning_flags)
 

--- a/source/cpp/CMakeLists.txt
+++ b/source/cpp/CMakeLists.txt
@@ -1,12 +1,4 @@
-add_library (
-  focusrite-e2e
-  include/focusrite/e2e/ClickableComponent.h
-  include/focusrite/e2e/Command.h
-  include/focusrite/e2e/CommandHandler.h
-  include/focusrite/e2e/ComponentSearch.h
-  include/focusrite/e2e/Event.h
-  include/focusrite/e2e/Response.h
-  include/focusrite/e2e/TestCentre.h
+add_library (focusrite-e2e STATIC
   source/Command.cpp
   source/ComponentSearch.cpp
   source/Connection.cpp
@@ -23,23 +15,7 @@ add_library (focusrite-e2e::focusrite-e2e ALIAS focusrite-e2e)
 
 target_include_directories (focusrite-e2e PUBLIC include)
 
-set (JUCE_MODULES juce_core juce_events)
-
-foreach (JUCE_MODULE ${JUCE_MODULES})
- 
-  if (NOT TARGET ${JUCE_MODULE})
-    message(FATAL_ERROR "Missing JUCE module: ${JUCE_MODULE}, enable FOCUSRITE_E2E_FETCH_JUCE to fetch JUCE")
-  endif()
-
-  get_target_property (MODULE_INCLUDES ${JUCE_MODULE}
-                       INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories (focusrite-e2e PUBLIC ${MODULE_INCLUDES})
-endforeach ()
-
-target_include_directories (focusrite-e2e PRIVATE ${juce_SOURCE_DIR}/modules)
-
-target_compile_definitions (focusrite-e2e
-                            PRIVATE JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1)
+target_link_libraries(focusrite-e2e PUBLIC focusrite-e2e::juce_modules)
 
 set_common_target_properties (focusrite-e2e)
 


### PR DESCRIPTION
**Describe what your code does**

- Updates the build to work on Linux
- Updates the example to use the same compile definitions on every include of a JUCE header.

This is a breaking change, and all users need to update their CMake files to provide the `focusrite-e2e::juce_modules`, which is used to link to JUCE using the same compile definitions used by the user application.

**Is this pull request to fix a bug?**

Fixes #175. The change is based on advice from the forum: https://forum.juce.com/t/compile-juce-modules-to-static-libraries/43255/2. I use the same method in my own project where I have DSP libraries that depend on JUCE and an application that depends on those libraries.

**Is this pull request to extend the functionality of the codebase?**

Is this a feature you are proposing? If so, please describe why it is required, what it does etc.

**Is the code tested?**

We require a high level of code test coverage - please make sure that you have run tests on your code. You can learn more about running the tests in the readme.md in the root of the repository.

I have ran the build in my machine on Linux. I expect the rest can be covered in CI and by reviewers. At the moment I can not test on Windows or MacOS, but I can set up Windows if required. The changes should be compatible with all platforms.

I have compiled and tested the example app using the following commands:

```
cmake -B cmake-build -G Ninja -DFOCUSRITE_E2E_MAKE_TESTS=ON -DFOCUSRITE_E2E_FETCH_JUCE=ON
cmake --build cmake-build
APP_PATH=cmake-build/example/app/e2e-example-app_artefacts/e2e-example-app npm run test-example
```

By submitting a pull request to this repository you are agreeing to assign the copyright on your submitted code to Focusrite Audio Engineering Ltd. Please check the box below to show you accept these terms. 

- [x] __I agree to assign copyright of any code accepted via this pull request process to Focusrite Audio engineering Ltd.__
