### PR TITLE
Clear timeout timer when queryFunction resolves

### DIFF
--- a/tests/poll-until.spec.ts
+++ b/tests/poll-until.spec.ts
@@ -7,30 +7,29 @@ describe('using pollUntil to see if a function matches a value', () => {
   const functionThatReturns42 = () => Promise.resolve(42);
   const timeoutMs = 10;
 
-  it('returns true if the expected value is returned within the timeout time', async () => {
-    const didReturnExpectedValue = await pollUntil(
+  it('resolves if the expected value is returned within the timeout time', async () => {
+    const didReturnExpectedValue = pollUntil(
       (currentResult) => currentResult === 42,
       functionThatReturns42,
       timeoutMs
     );
 
-    expect(didReturnExpectedValue).toBe(true);
+    await expect(didReturnExpectedValue).resolves.not.toThrow();
   });
 
-  it('returns false if the expected value is not returned within the timeout time', async () => {
-    const didReturnExpectedValue = await pollUntil(
+  it('rejects if the expected value is not returned within the timeout time', async () => {
+    const didReturnExpectedValue = pollUntil(
       (currentResult) => currentResult === 21,
       functionThatReturns42,
       timeoutMs
     );
-
-    expect(didReturnExpectedValue).toBe(false);
+    await expect(didReturnExpectedValue).rejects.toThrow();
   });
 
-  it('returns false if the query function never returns anything within the timeout time', async () => {
+  it('rejects if the query function never returns anything within the timeout time', async () => {
     const longerThanTheTimeout = timeoutMs * 2;
 
-    const didReturnExpectedValue = await pollUntil(
+    const didReturnExpectedValue = pollUntil(
       (currentResult) => currentResult === 42,
       async () => {
         await wait(longerThanTheTimeout);
@@ -39,6 +38,6 @@ describe('using pollUntil to see if a function matches a value', () => {
       timeoutMs
     );
 
-    expect(didReturnExpectedValue).toBe(false);
+    await expect(didReturnExpectedValue).rejects.toThrow();
   });
 });

--- a/tests/wait-for-result.spec.ts
+++ b/tests/wait-for-result.spec.ts
@@ -7,13 +7,14 @@ describe('waiting for a function to return a particular value', () => {
   it('becomes the expected value within the timeout time', async () => {
     const expectedValue = 42;
 
-    await waitForResult(functionThatReturns42, expectedValue, timeoutMs);
+    await expect(
+      waitForResult(functionThatReturns42, expectedValue, timeoutMs)
+    ).resolves.not.toThrow();
   });
 
   it('throws when the function does not return the expected value within the timeout time', async () => {
     const expectedValue = 13;
-
-    expect(
+    await expect(
       waitForResult(functionThatReturns42, expectedValue, timeoutMs)
     ).rejects.toThrow();
   });


### PR DESCRIPTION
**Is this pull request to fix a bug?**

Jest would warn of openHandles as the promise being rejected still had a setTimeout running.

Also updated the function signature of pollUntil to return a promise rather than a bool.

By submitting a pull request to this repository you are agreeing to assign the copyright on your submitted code to Focusrite Audio Engineering Ltd. Please check the box below to show you accept these terms. 

- [x] __I agree to assign copyright of any code accepted via this pull request process to Focusrite Audio engineering Ltd.__
