### PR TITLE
Fix race condition in dir create

### DIFF
--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -82,16 +82,10 @@ export class AppConnection extends EventEmitter {
       this.server = null;
     });
 
-    if (this.logDirectory && !fs.existsSync(this.logDirectory)) {
-      try {
-        fs.mkdirSync(this.logDirectory, {
-          recursive: true,
-        });
-      } catch (error) {
-        if (error.code !== 'EEXIST') {
-          throw error;
-        }
-      }
+    if (this.logDirectory) {
+      fs.mkdirSync(this.logDirectory, {
+        recursive: true,
+      });
     }
   }
 

--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -83,7 +83,15 @@ export class AppConnection extends EventEmitter {
     });
 
     if (this.logDirectory && !fs.existsSync(this.logDirectory)) {
-      fs.mkdirSync(this.logDirectory);
+      try {
+        fs.mkdirSync(this.logDirectory, {
+          recursive: true,
+        });
+      } catch (error) {
+        if (error.code !== 'EEXIST') {
+          throw error;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## What?

When making the log directory there was a race condition between checking if the dir exists and actually making the directory. This specifically gets shown up on windows when running multiple app instances, but can occur on Mac too:

```
if (this.logDirectory && !fs.existsSync(this.logDirectory)) {
        fs.mkdirSync(this.logDirectory);
}
```
Essentially, the check and create are non atomic, so if another process creates the directory after this process has checked for the existence, the call to `fs.mkdirSync` with throw an error with the code `EEXIST`.

Ive implemented 2 changes:

First, ive added the recursive flag. This means that `mkdirSync` behaves like the unix `mkdir -p` and will create all path components. It also means that it won't error if the dir exists
Secondly, the code now catches and checks the error code. If it's not a "directory already exists" error, then it throws. Otherwise, we can safely ignore the error