### PR TITLE
Improve failure modes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
       - run: 
           name: Install CMake
           command: |
-            choco install cmake --version=3.28.0 --installargs '"ADD_CMAKE_TO_PATH=User"'
+            choco install cmake --version=3.27.9 --installargs '"ADD_CMAKE_TO_PATH=User"'
             PATH_TO_CMAKE='/c/Program Files/CMake/bin'
             echo "export PATH='$PATH_TO_CMAKE:$PATH'" >> $BASH_ENV
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,9 @@ commands:
       - run: 
           name: Install CMake
           command: |
-            curl -OsL https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-macos10.10-universal.tar.gz
-            tar xf cmake-3.21.3-macos10.10-universal.tar.gz --strip-components=1
-            rm cmake-3.21.3-macos10.10-universal.tar.gz
+            curl -o cmake.tar.gz -sL https://github.com/Kitware/CMake/releases/download/v3.28.0/cmake-3.28.0-macos-universal.tar.gz
+            tar xf cmake.tar.gz --strip-components=1
+            rm cmake.tar.gz
             chmod -R a+rwx "$PWD/CMake.app"
             export PATH="$PATH:$PWD/CMake.app/Contents/bin"
             sudo "$PWD/CMake.app/Contents/bin/cmake-gui" --install
@@ -78,7 +78,7 @@ commands:
       - run: 
           name: Install CMake
           command: |
-            choco install cmake --version=3.21.3 --installargs '"ADD_CMAKE_TO_PATH=User"'
+            choco install cmake --version=3.28.0 --installargs '"ADD_CMAKE_TO_PATH=User"'
             PATH_TO_CMAKE='/c/Program Files/CMake/bin'
             echo "export PATH='$PATH_TO_CMAKE:$PATH'" >> $BASH_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cmake-build-release
 node_modules
 dist
 .DS_Store
+logs

--- a/cmake/fetch-juce.cmake
+++ b/cmake/fetch-juce.cmake
@@ -1,5 +1,5 @@
 include (FetchContent)
 fetchcontent_declare (juce GIT_REPOSITORY https://github.com/juce-framework/JUCE
-                      GIT_TAG 7.0.2 GIT_SUBMODULES "")
+                      GIT_TAG 7.0.9 GIT_SUBMODULES "")
 
 fetchcontent_makeavailable (juce)

--- a/example/tests/failure-modes.spec.ts
+++ b/example/tests/failure-modes.spec.ts
@@ -1,0 +1,30 @@
+import {AppConnection} from '../../source/ts';
+import {appPath} from './app-path';
+
+describe('invalid component', () => {
+  let app: AppConnection;
+
+  beforeEach(async () => {
+    app = new AppConnection({appPath, logDirectory: 'logs'});
+    await app.launch();
+  });
+
+  afterEach(async () => {
+    await app.quit();
+  });
+
+  it('rejects invalid components', async () => {
+    await expect(
+      app.waitForComponentToBeVisible('invalid', 100)
+    ).rejects.toThrow();
+  });
+});
+
+it('rejects requests after the app has quit', async () => {
+  const app = new AppConnection({appPath, logDirectory: 'logs'});
+  await app.launch();
+  await app.quit();
+  await expect(
+    app.waitForComponentToBeVisible('value-label')
+  ).rejects.toThrow();
+});

--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -151,9 +151,9 @@ export class AppConnection extends EventEmitter {
     this.connection = new Connection(socket);
     this.connection.on('connect', () => this.emit('connect'));
     this.connection.on('disconnect', () => {
-      this.emit('disconnect');
-      this.connection.kill();
       this.server.close();
+      this.connection = undefined;
+      this.emit('disconnect');
     });
   }
 

--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -20,7 +20,6 @@ import {
 } from './responses';
 import {Command} from './commands';
 import minimatch from 'minimatch';
-import {strict as assert} from 'assert';
 import {waitForResult} from './poll';
 
 const writeFile = util.promisify(fs.writeFile);
@@ -168,7 +167,9 @@ export class AppConnection extends EventEmitter {
   }
 
   async sendCommand(command: Command): Promise<ResponseData> {
-    assert(this.connection);
+    if (!this.connection) {
+      throw new Error('Not connected to application');
+    }
     return await this.connection.send(command);
   }
 
@@ -183,7 +184,6 @@ export class AppConnection extends EventEmitter {
   async waitForExit(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.on('exit', ({code, signal}) => {
-        assert(!code && !signal);
         if (code || signal) {
           reject(`App exited with error: ${code || signal}`);
         }

--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -268,7 +268,9 @@ export class AppConnection extends EventEmitter {
     return response.value;
   }
 
-  async getAccessibilityState(componentId: string): Promise<AccessibilityResponse> {
+  async getAccessibilityState(
+    componentId: string
+  ): Promise<AccessibilityResponse> {
     return (await this.sendCommand({
       type: 'get-accessibility-state',
       args: {
@@ -308,8 +310,11 @@ export class AppConnection extends EventEmitter {
       },
     });
   }
-    
-  async setComboBoxSelectedItemIndex(comboBoxId: string, value: number): Promise<void> {
+
+  async setComboBoxSelectedItemIndex(
+    comboBoxId: string,
+    value: number
+  ): Promise<void> {
     await this.sendCommand({
       type: 'set-combo-box-selected-item-index',
       args: {
@@ -329,7 +334,7 @@ export class AppConnection extends EventEmitter {
 
     return response.value;
   }
-    
+
   async getComboBoxNumItems(comboBoxId: string): Promise<number> {
     const response = (await this.sendCommand({
       type: 'get-combo-box-num-items',
@@ -354,24 +359,19 @@ export class AppConnection extends EventEmitter {
     componentName: string,
     visibility: boolean,
     timeoutInMilliseconds = DEFAULT_TIMEOUT
-  ): Promise<boolean> {
+  ): Promise<void> {
     try {
       await waitForResult(
         () => this.getComponentVisibility(componentName),
         visibility,
         timeoutInMilliseconds
       );
-
-      return true;
     } catch (error) {
       const errorDescription = visibility ? 'visible' : 'hidden';
       const filename = `${++screenshotIndex}.png`;
-      console.error(
-        `Component '${componentName}' didn't become ${errorDescription}, writing screenshot to ${filename}`
-      );
       await this.saveScreenshot('', filename);
       throw new Error(
-        `Component '${componentName}' didn't become ${errorDescription}`
+        `Component '${componentName}' didn't become ${errorDescription} (see screenshot ${filename})`
       );
     }
   }
@@ -379,8 +379,8 @@ export class AppConnection extends EventEmitter {
   async waitForComponentToBeVisible(
     componentName: string,
     timeoutInMilliseconds = DEFAULT_TIMEOUT
-  ): Promise<boolean> {
-    return await this.waitForComponentVisibilityToBe(
+  ): Promise<void> {
+    await this.waitForComponentVisibilityToBe(
       componentName,
       true,
       timeoutInMilliseconds
@@ -464,12 +464,8 @@ export class AppConnection extends EventEmitter {
     })) as ScreenshotResponse;
 
     try {
-      await writeFile(
-        path.join(this.logDirectory, outFileName),
-        response.image,
-        'base64'
-      );
-      console.log(`Screenshot of ${componentId} written to ${outFileName}`);
+      const outputFile = path.join(this.logDirectory, outFileName);
+      await writeFile(outputFile, response.image, 'base64');
     } catch (error) {
       console.error(
         `Error writing screenshot of ${componentId} to ${outFileName}`

--- a/source/ts/connection.ts
+++ b/source/ts/connection.ts
@@ -33,17 +33,10 @@ export class Connection extends EventEmitter {
     this.waitingEvents = [];
     this.socket = socket;
 
-    this.socket.on('close', () => {
-      this.emit('disconnect');
-    });
-
-    this.socket.on('connect', () => {
-      this.emit('connect');
-    });
-
-    this.socket.on('data', (data) => {
-      this.responseStream.push(data);
-    });
+    this.socket.on('close', () => this.emit('disconnect'));
+    this.socket.on('end', () => this.socket.destroy());
+    this.socket.on('connect', () => this.emit('connect'));
+    this.socket.on('data', (data) => this.responseStream.push(data));
 
     this.responseStream.on('response', (response: Response) => {
       if (response.type === ResponseType.response) {

--- a/source/ts/poll.ts
+++ b/source/ts/poll.ts
@@ -14,11 +14,11 @@ const invokeWithTimeout = async <T>(
   );
 
   try {
-    const data = await Promise.race([queryFunction(), rejectingPromise]);
-    clearTimeout(timer);
-    return data;
+    return await Promise.race([queryFunction(), rejectingPromise]);
   } catch {
     throw new Error('Timed out.');
+  } finally {
+    clearTimeout(timer);
   }
 };
 

--- a/source/ts/server.ts
+++ b/source/ts/server.ts
@@ -1,5 +1,4 @@
 import net, {Socket} from 'net';
-import {strict as assert} from 'assert';
 import {EventEmitter} from 'events';
 
 export class Server extends EventEmitter {
@@ -19,7 +18,9 @@ export class Server extends EventEmitter {
 
   async listen(): Promise<number> {
     return new Promise((resolve) => {
-      assert(!this.server);
+      if (this.server) {
+        throw new Error('Server already running');
+      }
 
       this.server = new net.Server();
 
@@ -58,7 +59,10 @@ export class Server extends EventEmitter {
         resolve(this.lastConnection);
         this.lastConnection = null;
       } else {
-        assert(!!this.server);
+        if (!this.server) {
+          throw new Error('Missing TCP server');
+        }
+
         this.server.on('connection', (socket) => {
           resolve(socket);
         });


### PR DESCRIPTION
A few improvements to the behaviour when tests fail:
- If the app exits, it will destroy the socket (listening to the `end` event on the socket - see [here](https://nodejs.org/api/net.html#event-end)). Previously, the app exiting might have caused a hung test
- Changed `waitForComponentVisibility` to a void return type. Previously, it would return true if the component was visible and would throw an error if the component wasn't visible.
- Removed `assert`s in favour of throwing errors. This has a clearer behaviour