### PR TITLE
Extract the process out of the app connection

### DIFF
--- a/example/app/source/Application.h
+++ b/example/app/source/Application.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CustomCommandHandler.h"
 #include "MainWindow.h"
 
 #include <focusrite/e2e/TestCentre.h>
@@ -20,15 +21,21 @@ public:
 
     void initialise ([[maybe_unused]] const juce::String & commandLineArguments) override
     {
+        _testCentre = focusrite::e2e::TestCentre::create ();
+        _testCentre->addCommandHandler (_customCommandHandler);
+
         _mainWindow.setVisible (true);
     }
 
     void shutdown () override
     {
         _mainWindow.setVisible (false);
+
+        _testCentre.reset ();
     }
 
 private:
     MainWindow _mainWindow;
-    std::unique_ptr<focusrite::e2e::TestCentre> _testCentre = focusrite::e2e::TestCentre::create ();
+    CustomCommandHandler _customCommandHandler;
+    std::unique_ptr<focusrite::e2e::TestCentre> _testCentre;
 };

--- a/example/app/source/CustomCommandHandler.h
+++ b/example/app/source/CustomCommandHandler.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdlib>
+#include <focusrite/e2e/CommandHandler.h>
+
+class CustomCommandHandler : public focusrite::e2e::CommandHandler
+{
+public:
+    std::optional<focusrite::e2e::Response>
+    process (const focusrite::e2e::Command & command) override
+    {
+        if (command.getType () == "abort")
+            std::abort ();
+
+        return {};
+    }
+};

--- a/example/tests/failure-modes.spec.ts
+++ b/example/tests/failure-modes.spec.ts
@@ -13,18 +13,25 @@ describe('invalid component', () => {
     await app.quit();
   });
 
-  it('rejects invalid components', async () => {
-    await expect(
-      app.waitForComponentToBeVisible('invalid', 100)
-    ).rejects.toThrow();
+  it.failing('fails when waiting for invalid components', async () => {
+    await app.waitForComponentToBeVisible('invalid', 100);
+  });
+
+  it.failing('fails when waiting for an event that never happens', async () => {
+    await app.waitForEvent('my-event', undefined, 100);
   });
 });
 
-it('rejects requests after the app has quit', async () => {
+it.failing('rejects requests after the app has quit', async () => {
   const app = new AppConnection({appPath, logDirectory: 'logs'});
   await app.launch();
   await app.quit();
-  await expect(
-    app.waitForComponentToBeVisible('value-label')
-  ).rejects.toThrow();
+  await app.waitForComponentToBeVisible('value-label');
+});
+
+it.failing('fails when the app crashes', async () => {
+  const app = new AppConnection({appPath, logDirectory: 'logs'});
+  await app.launch();
+  app.sendCommand({type: 'abort'});
+  await app.waitForExit();
 });

--- a/source/cpp/include/focusrite/e2e/CommandHandler.h
+++ b/source/cpp/include/focusrite/e2e/CommandHandler.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <focusrite/e2e/Command.h>
 #include <focusrite/e2e/Response.h>
 #include <optional>
 

--- a/source/ts/app-process.ts
+++ b/source/ts/app-process.ts
@@ -1,0 +1,54 @@
+import {spawn} from 'child_process';
+import path from 'path';
+import fs from 'fs';
+
+export interface EnvironmentVariables {
+  [key: string]: string;
+}
+
+const nextRunId = (() => {
+  let runId = 1;
+
+  return () => {
+    return runId++;
+  };
+})();
+
+const createLogFiles = (logDirectory: string) => {
+  const runId = nextRunId();
+
+  const stdoutPath = path.join(
+    logDirectory,
+    `application-tests-stdout-${runId}.log`
+  );
+  const stderrPath = path.join(
+    logDirectory,
+    `application-tests-stderr-${runId}.log`
+  );
+
+  return {
+    stdout: fs.createWriteStream(stdoutPath, {flags: 'a'}),
+    stderr: fs.createWriteStream(stderrPath, {flags: 'a'}),
+  };
+};
+
+interface Options {
+  path: string;
+  logDirectory?: string;
+  extraArgs: string[];
+  env: EnvironmentVariables;
+}
+
+export const launchApp = ({path, extraArgs, env, logDirectory}: Options) => {
+  const process = spawn(path, extraArgs, {env});
+
+  if (logDirectory) {
+    const logs = createLogFiles(logDirectory);
+    process.stdout.pipe(logs.stdout);
+    process.stderr.pipe(logs.stderr);
+  }
+
+  return process;
+};
+
+export type AppProcess = ReturnType<typeof launchApp>;

--- a/source/ts/index.ts
+++ b/source/ts/index.ts
@@ -1,4 +1,5 @@
-export {AppConnection, EnvironmentVariables} from './app-connection';
+export {AppConnection} from './app-connection';
+export {EnvironmentVariables} from './app-process';
 export {Command} from './commands';
 export {Response, Event} from './responses';
 export {pollUntil, waitForResult} from './poll';


### PR DESCRIPTION
- Add a custom command called `abort`, that will abort the application
- Add a 'failing' test that checks a test will fail if it
- Extract everything relating to the child process from `AppConnection`