### PR TITLE
Add date to screenshot filename when a test fails

### DIFF
--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -328,7 +328,7 @@ export class AppConnection extends EventEmitter {
       );
     } catch (error) {
       const errorDescription = visibility ? 'visible' : 'hidden';
-      const filename = `${++screenshotIndex}.png`;
+      const filename = `${++screenshotIndex}-${new Date().toISOString()}.png`;
       await this.saveScreenshot('', filename);
       throw new Error(
         `Component '${componentName}' didn't become ${errorDescription} (see screenshot ${filename})`
@@ -364,7 +364,7 @@ export class AppConnection extends EventEmitter {
       const stateString = enablement ? 'enabled' : 'disabled';
       const failString = `Component '${componentName}' didn't become ${stateString}`;
 
-      const filename = `${++screenshotIndex}.png`;
+      const filename = `${++screenshotIndex}-${new Date().toISOString()}.png`;
       console.error(`${failString}, writing screenshot to ${filename}`);
       await this.saveScreenshot('', filename);
       throw new Error(failString);


### PR DESCRIPTION
**Describe what your code does**

Adds a date to the name of screenshots when a test fails. In cases where a test needs to be re-run multiple times, or tests are run in different sessions, these screenshots would get overwritten by the most recent test run failure. Adding a date makes these filenames unique and easily understandable.



By submitting a pull request to this repository you are agreeing to assign the copyright on your submitted code to Focusrite Audio Engineering Ltd. Please check the box below to show you accept these terms. 

- [x] __I agree to assign copyright of any code accepted via this pull request process to Focusrite Audio engineering Ltd.__
