### PR TITLE
Add Component handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-# JUCE End to End test framework
+# JUCE End to End
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/FocusriteGroup/juce-end-to-end/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/FocusriteGroup/juce-end-to-end/tree/main)
-
-[![Platform](https://img.shields.io/static/v1?label=Platform&message=macOS%20%7C%20windows&color=pink&style=flat)](./documentation/building.md)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) [![CircleCI](https://dl.circleci.com/status-badge/img/gh/FocusriteGroup/juce-end-to-end/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/FocusriteGroup/juce-end-to-end/tree/main) [![Platform](https://img.shields.io/static/v1?label=Platform&message=macOS%20%7C%20windows&color=pink&style=flat)](./documentation/building.md)
 
 [![Language](https://img.shields.io/static/v1?label=Language&message=C%2B%2B&color=orange&style=flat)](./documentation/building.md)
 [![Code Style](https://img.shields.io/static/v1?label=Code%20Style&message=Clang%20Format&color=pink&style=flat)](https://clang.llvm.org/docs/ClangFormat.html)
@@ -17,22 +11,26 @@
 [![Language](https://img.shields.io/static/v1?label=Language&message=CMake&color=orange&style=flat)](https://www.cmake.org)
 [![Code Style](https://img.shields.io/static/v1?label=Code%20Style&message=CMake%20Format&color=pink&style=flat)](https://github.com/cheshirekow/cmake_format)
 
-## What is it?
-
-This package provides a mechanism to end-to-end test a JUCE application
+A framework for end-to-end testing JUCE applications using JavaScript.
 
 ## Prerequisites
 
-- [CMake](https://www.cmake.org). Must be 3.18 or higher. Normally just get the latest version
-  - CMake is used as the build system, as we as a pseudo package manager. It is the simplest way to use JE2E
-- [Node](https://nodejs.org/en/). See the [package.json](./package.json) for the supported version(s).
-  - Node is used to manage the build and test process. You can manually execute any of the normal commands in Cmake and your compiler if you don't wish to use Node
-- [JUCE](https://juce.com). Should be >= 6.x
-  - This project is designed to integrate with JUCE. We use large parts of the JUCE mainline. To make this project work, JUCE should be available on your compile path
+- [JUCE](https://juce.com) 6 or later
+- [CMake](https://cmake.org) 3.18 or higher
 
 ## Integration guide
 
-To integrate into your project, please read the [Integration Guide](./documentation/integration-guide.md)
+See the full [Integration Guide](./documentation/integration-guide.md) for a detailed walkthrough - the major steps are:
+
+1. Add the `focusrite-e2e` library to your JUCE application using CMake
+1. Write a `TestCentre` to allow JavaScript to communicate with your app
+1. Create an `AppConnection` object in your favourite JavaScript test framework and use its various methods to test your app
+
+See the [example app](./example/) for an example of how to integrate this framework in your JUCE app.
+
+Watch Joe's ADC talk for an even more detailed explanation of the framework, and to see it in action testing Ampify Studio!
+
+[![Joe's ADC Talk](https://img.youtube.com/vi/3gi7CO71414/0.jpg)](https://www.youtube.com/watch?v=3gi7CO71414)
 
 ## Continuous Integration
 

--- a/example/tests/accessibility.spec.ts
+++ b/example/tests/accessibility.spec.ts
@@ -21,7 +21,7 @@ describe('Accessibility tests', () => {
     window = appConnection.getComponent('main-window');
 
     await appConnection.launch();
-    valueLabel.waitToBeVisible();
+    await valueLabel.waitToBeVisible();
   });
 
   afterEach(async () => {

--- a/example/tests/accessibility.spec.ts
+++ b/example/tests/accessibility.spec.ts
@@ -1,13 +1,27 @@
 import {AppConnection} from '../../source/ts';
+import {ComponentHandle} from '../../source/ts/component-handle';
 import {appPath} from './app-path';
 
 describe('Accessibility tests', () => {
   let appConnection: AppConnection;
+  let valueLabel: ComponentHandle;
+  let incrementButton: ComponentHandle;
+  let decrementButton: ComponentHandle;
+  let enableButton: ComponentHandle;
+  let slider: ComponentHandle;
+  let window: ComponentHandle;
 
   beforeEach(async () => {
     appConnection = new AppConnection({appPath});
+    valueLabel = appConnection.getComponent('value-label');
+    incrementButton = appConnection.getComponent('increment-button');
+    decrementButton = appConnection.getComponent('decrement-button');
+    enableButton = appConnection.getComponent('enable-button');
+    slider = appConnection.getComponent('slider');
+    window = appConnection.getComponent('main-window');
+
     await appConnection.launch();
-    await appConnection.waitForComponentToBeVisible('value-label');
+    valueLabel.waitToBeVisible();
   });
 
   afterEach(async () => {
@@ -15,9 +29,7 @@ describe('Accessibility tests', () => {
   });
 
   it('Increment button is accessible', async () => {
-    expect(
-      await appConnection.getAccessibilityState('increment-button')
-    ).toEqual({
+    expect(incrementButton.getAccessibilityState()).resolves.toEqual({
       title: 'Increment button title',
       description: 'Increment button description',
       help: 'Increment button tool tip',
@@ -28,72 +40,62 @@ describe('Accessibility tests', () => {
   });
 
   it('Decrement button is not accessible', async () => {
-    const state = await appConnection.getAccessibilityState('decrement-button');
+    const state = await decrementButton.getAccessibilityState();
     expect(state.accessible).toBeFalsy();
     expect(state.handler).toBeFalsy();
   });
 
   it('Enable button is enabled for accessibility but has no text', async () => {
-    const state = await appConnection.getAccessibilityState('enable-button');
+    const state = await enableButton.getAccessibilityState();
     expect(state.accessible).toBeTruthy();
     expect(state.handler).toBeTruthy();
   });
 
   it('Slider is enabled for accessibility but has no text', async () => {
-    const state = await appConnection.getAccessibilityState('slider');
+    const state = await slider.getAccessibilityState();
     expect(state.accessible).toBeTruthy();
     expect(state.handler).toBeTruthy();
     expect(parseFloat(state.display)).toEqual(0);
   });
 
   it('Slider display changes with the value change', async () => {
-    expect(
-      parseFloat((await appConnection.getAccessibilityState('slider')).display)
-    ).toEqual(0);
+    expect(parseFloat((await slider.getAccessibilityState()).display)).toEqual(
+      0
+    );
 
-    await appConnection.clickComponent('increment-button');
-    expect(
-      parseFloat((await appConnection.getAccessibilityState('slider')).display)
-    ).toEqual(1);
+    await incrementButton.click();
+    expect(parseFloat((await slider.getAccessibilityState()).display)).toEqual(
+      1
+    );
 
-    await appConnection.clickComponent('decrement-button');
-    expect(
-      parseFloat((await appConnection.getAccessibilityState('slider')).display)
-    ).toEqual(0);
+    await decrementButton.click();
+    expect(parseFloat((await slider.getAccessibilityState()).display)).toEqual(
+      0
+    );
   });
 
   it('Increment button has accessibility parent', async () => {
-    expect(
-      await appConnection.getAccessibilityParent('increment-button')
-    ).toEqual('main-window');
-    expect(await appConnection.getAccessibilityParent('enable-button')).toEqual(
-      'main-window'
+    expect(incrementButton.getAccessibilityParent()).resolves.toEqual(
+      window.componentID
     );
-    expect(await appConnection.getAccessibilityParent('slider')).toEqual(
-      'main-window'
+    expect(enableButton.getAccessibilityParent()).resolves.toEqual(
+      window.componentID
+    );
+    expect(slider.getAccessibilityParent()).resolves.toEqual(
+      window.componentID
     );
   });
 
   it('Decrement button has no accessibility parent', async () => {
-    expect(
-      await appConnection.getAccessibilityParent('decrement-button')
-    ).toEqual('');
+    expect(decrementButton.getAccessibilityParent()).resolves.toEqual('');
   });
 
   it('Main window has multiple accessible children', async () => {
-    const children = await appConnection.getAccessibilityChildren(
-      'main-window'
-    );
+    const children = await window.getAccessibilityChildren();
     expect(children.length).toBeGreaterThan(0);
-    expect(children).toContainEqual('increment-button');
-    expect(children).toContainEqual('enable-button');
-    expect(children).toContainEqual('slider');
-  });
-
-  it('Decrement is not a child of the main window', async () => {
-    const children = await appConnection.getAccessibilityChildren(
-      'main-window'
-    );
-    expect(children.find((str) => str === 'disable-button')).toBeFalsy();
+    expect(children).toContainEqual(incrementButton.componentID);
+    expect(children).toContainEqual(enableButton.componentID);
+    expect(children).toContainEqual(slider.componentID);
+    expect(children.includes(decrementButton.componentID)).toBeFalsy();
   });
 });

--- a/example/tests/counter-app.spec.ts
+++ b/example/tests/counter-app.spec.ts
@@ -1,13 +1,29 @@
 import {AppConnection} from '../../source/ts';
 import {appPath} from './app-path';
+import {ComponentHandle} from '../../source/ts/component-handle';
 
 describe('Count App tests', () => {
   let appConnection: AppConnection;
+  let valueLabel: ComponentHandle;
+  let incrementButton: ComponentHandle;
+  let decrementButton: ComponentHandle;
+  let enableButton: ComponentHandle;
+  let slider: ComponentHandle;
+  let textEditor: ComponentHandle;
+  let comboBox: ComponentHandle;
 
   beforeEach(async () => {
     appConnection = new AppConnection({appPath});
+    valueLabel = appConnection.getComponent('value-label');
+    incrementButton = appConnection.getComponent('increment-button');
+    decrementButton = appConnection.getComponent('decrement-button');
+    enableButton = appConnection.getComponent('enable-button');
+    slider = appConnection.getComponent('slider');
+    textEditor = appConnection.getComponent('text-editor');
+    comboBox = appConnection.getComponent('combo-box');
+
     await appConnection.launch();
-    await appConnection.waitForComponentToBeVisible('value-label');
+    await valueLabel.waitToBeVisible();
   });
 
   afterEach(async () => {
@@ -15,70 +31,56 @@ describe('Count App tests', () => {
   });
 
   it('starts at 0', async () => {
-    const value = await appConnection.getComponentText('value-label');
-    expect(value).toEqual('0');
+    expect(valueLabel.getText()).resolves.toEqual('0');
   });
 
   it('increments using the increment button', async () => {
-    await appConnection.clickComponent('increment-button');
-
-    const value = await appConnection.getComponentText('value-label');
-    expect(value).toEqual('1');
+    await incrementButton.click();
+    expect(valueLabel.getText()).resolves.toEqual('1');
   });
 
   it('decrements using the decrement button', async () => {
-    await appConnection.clickComponent('decrement-button');
-
-    const value = await appConnection.getComponentText('value-label');
-    expect(value).toEqual('-1');
+    await decrementButton.click();
+    expect(valueLabel.getText()).resolves.toEqual('-1');
   });
 
   it('can be disabled', async () => {
-    expect(
-      await appConnection.getComponentEnablement('increment-button')
-    ).toBeTruthy();
-    expect(
-      await appConnection.getComponentEnablement('decrement-button')
-    ).toBeTruthy();
+    expect(incrementButton.getEnablement()).resolves.toBeTruthy();
+    expect(decrementButton.getEnablement()).resolves.toBeTruthy();
 
-    await appConnection.clickComponent('enable-button');
+    await enableButton.click();
 
-    expect(
-      await appConnection.getComponentEnablement('increment-button')
-    ).toBeFalsy();
-    expect(
-      await appConnection.getComponentEnablement('decrement-button')
-    ).toBeFalsy();
+    expect(incrementButton.getEnablement()).resolves.toBeFalsy();
+    expect(decrementButton.getEnablement()).resolves.toBeFalsy();
   });
 
   it('sets value using the slider', async () => {
+    expect(slider.getSliderValue()).resolves.toBe(0);
+
     const expectedValue = 6;
-    await appConnection.setSliderValue('slider', expectedValue);
-    const value = await appConnection.getSliderValue('slider');
-    expect(value).toBe(expectedValue);
+    slider.setSliderValue(expectedValue);
+    expect(slider.getSliderValue()).resolves.toBe(expectedValue);
   });
 
   it('sets value using the text editor', async () => {
-    const expectedValue = 789;
-    await appConnection.setTextEditorText('text-editor', `${expectedValue}`);
-    const value = await appConnection.getComponentText('value-label');
-    expect(value).toBe(`${expectedValue}`);
+    const expectedValue = '789';
+    await textEditor.setTextEditorText(expectedValue);
+    expect(valueLabel.getText()).resolves.toBe(expectedValue);
   });
-    
+
   it('sets value using the combo-box', async () => {
     const expectedValue = 2;
-    await appConnection.setComboBoxSelectedItemIndex('combo-box', expectedValue);
-    const value = await appConnection.getComboBoxSelectedItemIndex('combo-box');
-    expect(value).toBe(expectedValue);
+    await comboBox.setComboBoxSelectedItemIndex(expectedValue);
+    expect(comboBox.getComboBoxSelectedItemIndex()).resolves.toBe(
+      expectedValue
+    );
   });
 
   it('checks that all values in combox box are present and in the correct order', async () => {
-    const expectedValues = ['First', 'Second', 'Third'];
-    const items = await appConnection.getComboBoxItems('combo-box');
-    let index = 0;
-    for (const value of expectedValues) {
-      expect(value).toEqual(items[index]);
-      index++;
-    }
+    expect(comboBox.getComboBoxItems()).resolves.toStrictEqual([
+      'First',
+      'Second',
+      'Third',
+    ]);
   });
 });

--- a/example/tests/failure-modes.spec.ts
+++ b/example/tests/failure-modes.spec.ts
@@ -1,4 +1,5 @@
 import {AppConnection} from '../../source/ts';
+import {ComponentHandle} from '../../source/ts/component-handle';
 import {appPath} from './app-path';
 
 describe('invalid component', () => {
@@ -14,7 +15,7 @@ describe('invalid component', () => {
   });
 
   it.failing('fails when waiting for invalid components', async () => {
-    await app.waitForComponentToBeVisible('invalid', 100);
+    await app.getComponent('invalid').waitToBeVisible(100);
   });
 
   it.failing('fails when waiting for an event that never happens', async () => {
@@ -26,7 +27,7 @@ it.failing('rejects requests after the app has quit', async () => {
   const app = new AppConnection({appPath, logDirectory: 'logs'});
   await app.launch();
   await app.quit();
-  await app.waitForComponentToBeVisible('value-label');
+  await app.getComponent('value-label').waitToBeVisible(100);
 });
 
 it.failing('fails when the app crashes', async () => {

--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -23,6 +23,7 @@ import {Command} from './commands';
 import {minimatch} from 'minimatch';
 import {waitForResult} from './poll';
 import {AppProcess, EnvironmentVariables, launchApp} from './app-process';
+import {ComponentHandle} from './component-handle';
 
 const writeFile = util.promisify(fs.writeFile);
 
@@ -506,5 +507,9 @@ export class AppConnection extends EventEmitter {
     }
 
     return false;
+  }
+
+  getComponent(componentID: string) {
+    return new ComponentHandle(componentID, this);
   }
 }

--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -33,7 +33,7 @@ interface AppConnectionOptions {
   logDirectory?: string;
 }
 
-const DEFAULT_TIMEOUT = 5000;
+export const DEFAULT_TIMEOUT = 5000;
 
 const existsAsFile = (path: string) => {
   try {

--- a/source/ts/component-handle.ts
+++ b/source/ts/component-handle.ts
@@ -1,0 +1,149 @@
+import {AppConnection} from '.';
+import {AccessibilityResponse} from './responses';
+import {DEFAULT_TIMEOUT} from './app-connection';
+import {time} from 'console';
+
+export class ComponentHandle {
+  appConnection: AppConnection;
+  componentID: string;
+
+  constructor(componentID: string, appConnection: AppConnection) {
+    this.appConnection = appConnection;
+    this.componentID = componentID;
+  }
+
+  async waitToBeVisible(timeoutInMilliseconds?: number) {
+    await this.appConnection.waitForComponentToBeVisible(
+      this.componentID,
+      timeoutInMilliseconds
+    );
+  }
+
+  async waitForVisibilityToBe(
+    visibility: boolean,
+    timeoutInMilliseconds = DEFAULT_TIMEOUT
+  ) {
+    await this.appConnection.waitForComponentVisibilityToBe(
+      this.componentID,
+      visibility,
+      timeoutInMilliseconds
+    );
+  }
+
+  async isVisible(): Promise<boolean> {
+    return this.appConnection.getComponentVisibility(this.componentID);
+  }
+
+  async waitToBeEnabled(timeoutInMilliseconds = DEFAULT_TIMEOUT) {
+    await this.appConnection.waitForComponentToBeEnabled(
+      this.componentID,
+      timeoutInMilliseconds
+    );
+  }
+
+  async waitToBeDisabled(timeoutInMilliseconds = DEFAULT_TIMEOUT) {
+    await this.appConnection.waitForComponentToBeDisabled(
+      this.componentID,
+      timeoutInMilliseconds
+    );
+  }
+
+  async waitForEnablementToBe(
+    enablement: boolean,
+    timeoutInMilliseconds = DEFAULT_TIMEOUT
+  ) {
+    await this.appConnection.waitForComponentEnablementToBe(
+      this.componentID,
+      enablement,
+      timeoutInMilliseconds
+    );
+  }
+
+  async isEnabled(): Promise<boolean> {
+    return this.appConnection.getComponentEnablement(this.componentID);
+  }
+
+  async getText(): Promise<string> {
+    return this.appConnection.getComponentText(this.componentID);
+  }
+
+  async setTextEditorText(text: string) {
+    await this.appConnection.setTextEditorText(this.componentID, text);
+  }
+
+  async getEnablement(): Promise<boolean> {
+    return this.appConnection.getComponentEnablement(this.componentID);
+  }
+
+  async click(skip?: number) {
+    await this.appConnection.clickComponent(this.componentID, skip);
+  }
+
+  async doubleClick(skip?: number) {
+    await this.appConnection.doubleClickComponent(this.componentID, skip);
+  }
+
+  async getSliderValue(): Promise<number> {
+    return this.appConnection.getSliderValue(this.componentID);
+  }
+
+  async setSliderValue(value: number) {
+    await this.appConnection.setSliderValue(this.componentID, value);
+  }
+
+  async getComboBoxSelectedItemIndex(): Promise<number> {
+    return this.appConnection.getComboBoxSelectedItemIndex(this.componentID);
+  }
+
+  async setComboBoxSelectedItemIndex(index: number) {
+    await this.appConnection.setComboBoxSelectedItemIndex(
+      this.componentID,
+      index
+    );
+  }
+
+  async getComboBoxItems(): Promise<string[]> {
+    return this.appConnection.getComboBoxItems(this.componentID);
+  }
+
+  async getComboBoxNumItems(): Promise<number> {
+    return this.appConnection.getComboBoxNumItems(this.componentID);
+  }
+
+  async getAccessibilityState(): Promise<AccessibilityResponse> {
+    return this.appConnection.getAccessibilityState(this.componentID);
+  }
+
+  async getAccessibilityParent(): Promise<string> {
+    return this.appConnection.getAccessibilityParent(this.componentID);
+  }
+
+  async getAccessibilityChildren(): Promise<Array<string>> {
+    return this.appConnection.getAccessibilityChildren(this.componentID);
+  }
+
+  async keyPress(key: string, modifiers?: string) {
+    await this.appConnection.keyPress(key, modifiers, this.componentID);
+  }
+
+  async isFocused(): Promise<boolean> {
+    return (
+      (await this.appConnection.getFocusedComponent()) === this.componentID
+    );
+  }
+
+  async tabTo(maxNumComponents = 1024): Promise<boolean> {
+    return this.appConnection.tabToComponent(
+      this.componentID,
+      maxNumComponents
+    );
+  }
+
+  async getNumChildrenWithID(childID: string): Promise<number> {
+    return this.appConnection.countComponents(childID, this.componentID);
+  }
+
+  async saveScreenshot(outFileName: string) {
+    await this.appConnection.saveScreenshot(this.componentID, outFileName);
+  }
+}


### PR DESCRIPTION
Adds a `ComponentHandle` JavaScript class that makes interacting with specific Components more convenient by removing the need to repeatedly specify the ComponentID for each all.

This approach also hopes to aid readability of the tests by making it clearer when we're specifically interacting with components in the UI, rather than other aspects of the app.